### PR TITLE
Updated host monitoring volume entry in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ services:
      - API_KEY=__your_datadog_api_key_here__
     volumes:
      - /var/run/docker.sock:/var/run/docker.sock
-     - /proc/mounts:/host/proc/mounts:ro
+     - /proc/:/host/proc:ro
      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
 ```
 


### PR DESCRIPTION
If you use the docker-compose example verbatim, the dashboard will report the following:

```
Datadog's docker_daemon integration is reporting:
Instance #0[WARNING]:Unable to find any pid directory in /host/proc. If you are running the agent in a container, make sure to share the volume properly: "/proc:/host/proc:ro". See https://github.com/DataDog/docker-dd-agent/blob/master/README.md for more information. Network metrics will be missing
```