### PR TITLE
Fix config to allow statsd metric to be received

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
      - web # ensures that the web app can send metrics
     environment:
      - DD_API_KEY=__your_datadog_api_key_here__
+     - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
     volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - /proc/:/host/proc/:ro


### PR DESCRIPTION
Without DD_DOGSTATSD_NON_LOCAL_TRAFFIC, the agent binds to localhost, and therefore does not receive cross-container statsd traffic from the web container.