### PR TITLE
Links depcreated, opening ports instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,24 @@ services:
      - "5000:5000"
     volumes:
      - ./web:/code # modified here to take into account the new app path
-    links:
-     - redis
     environment:
      - DATADOG_HOST=datadog # used by the web app to initialize the Datadog library
   redis:
     image: redis
+    ports:
+     - "6379:6379"
   # agent section
   datadog:
     build: datadog
-    links:
-     - redis # ensures that redis is a host that the container can find
-     - web # ensures that the web app can send metrics
     environment:
      - DD_API_KEY=__your_datadog_api_key_here__
+     - DD_DOGTAND_NON_LOCAL_TRAFFIC=true
     volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - /proc/:/host/proc/:ro
      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+    ports:
+     - "8125:8125/udp"
 ```
 
 # Configuring the Agent
@@ -60,11 +60,11 @@ FROM datadog/agent:latest
 ADD conf.d/redisdb.yaml /etc/datadog-agent/conf.d/redisdb.yaml
 ```
 
-And the Compose yaml files creates the link to redis with:
+And the Compose yaml files opens the port on the host for other containers to connect to:
 
 ```yaml
-  links:
-    - redis
+  ports:
+   - "8125:8125/udp"
 ```
 
 # All in one

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,12 @@ services:
      - "5000:5000"
     volumes:
      - ./web:/code # modified here to take into account the new app path
-    links:
-     - redis
     environment:
      - DATADOG_HOST=datadog # used by the web app to initialize the Datadog library
   redis:
     image: redis
+    ports:
+     - "6379:6379"
   # agent section
   datadog:
     build: datadog
@@ -26,3 +26,5 @@ services:
      - /var/run/docker.sock:/var/run/docker.sock
      - /proc/:/host/proc/:ro
      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
+    ports:
+     - "8125:8125/udp"


### PR DESCRIPTION
Docker links deprecated per: https://docs.docker.com/network/links/

Removed and switched to opening ports for Datadog Agent and Redis 